### PR TITLE
Print a diff of new images + commit messages when deploying

### DIFF
--- a/release_tooling/requirements.in
+++ b/release_tooling/requirements.in
@@ -3,3 +3,4 @@ pytest
 click
 requests
 python-terraform
+termcolor

--- a/release_tooling/requirements.txt
+++ b/release_tooling/requirements.txt
@@ -19,7 +19,8 @@ python-terraform==0.10.1
 requests==2.21.0
 s3transfer==0.2.0         # via boto3
 six==1.11.0               # via python-dateutil
+termcolor==1.1.0
 urllib3==1.24.3           # via botocore, requests
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via pytest
+# setuptools


### PR DESCRIPTION
When you run "deploy" with the release tool, it prints a dict of the image tags it wants to apply. This isn't very helpful, unless you fancy memorising a whole stack of SHA-1 hashes.

This patch modifies the "deploy" command to print a diff of new image IDs, and the associated commit message:

![Screenshot 2020-05-12 at 14 05 15](https://user-images.githubusercontent.com/301220/81695176-2bbd1180-945a-11ea-96af-27d38a1e4e91.png)

I can see I'm about to deploy pull requests #501 and #503. Much more useful!

If there aren't any changes, it tells you that too:

![Screenshot 2020-05-12 at 14 05 05](https://user-images.githubusercontent.com/301220/81695303-5909bf80-945a-11ea-8f95-0c2cde2dc731.png)

This is something I've wanted for a while, and should make it easier to see what we're deploying.